### PR TITLE
Implement topic listing and session logging API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Features:
 - Per-IP Rate limiting using Cloudflare's [KV](https://developers.cloudflare.com/kv/)
 - OCR is running inside Cloudflare Worker using [unpdf](https://github.com/unjs/unpdf)
 - Smart Placement automatically places your workloads in an optimal location that minimizes latency and speeds up your applications
+- REST endpoints for listing topics and logging sessions with an OpenAPI 3.1 specification
 
 
 ## Development

--- a/drizzle/20240831120000_add_email_and_session_tables.sql
+++ b/drizzle/20240831120000_add_email_and_session_tables.sql
@@ -1,0 +1,52 @@
+CREATE TABLE email_threads (
+  thread_id TEXT PRIMARY KEY,
+  thread_url TEXT,
+  pdf_url TEXT,
+  num_messages INTEGER,
+  num_attachments INTEGER,
+  attachments_json TEXT,
+  parties TEXT,
+  subject TEXT,
+  date_first_message TIMESTAMP,
+  date_last_message TIMESTAMP,
+  tags TEXT,
+  main_topic TEXT,
+  message_summaries_json TEXT,
+  rag_key TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE email_docs (
+  doc_id TEXT PRIMARY KEY,
+  source TEXT,
+  parent_id TEXT,
+  drive_url TEXT,
+  r2_file_url TEXT,
+  parent_folder_id TEXT,
+  pdf_url TEXT,
+  title TEXT,
+  type TEXT,
+  tags TEXT,
+  main_topic TEXT,
+  related_thread_id TEXT,
+  description TEXT,
+  gemini_summary TEXT,
+  gemini_topics TEXT,
+  date_uploaded TIMESTAMP,
+  uploaded_by TEXT,
+  file_size_bytes INTEGER,
+  mime_type TEXT,
+  rag_key TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE chat_sessions (
+  session_id TEXT PRIMARY KEY,
+  main_topic TEXT,
+  user_prompt TEXT,
+  vector_results_json TEXT,
+  r2_output_url TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/functions/api/sessions.ts
+++ b/functions/api/sessions.ts
@@ -1,0 +1,32 @@
+import { drizzle } from 'drizzle-orm/d1';
+import { chatSessions } from '../../schema';
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  if (ctx.request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const auth = ctx.request.headers.get('Authorization');
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  try {
+    const body = await ctx.request.json();
+    const db = drizzle(ctx.env.DB);
+    await db.insert(chatSessions).values({
+      sessionId: body.sessionId,
+      mainTopic: body.mainTopic,
+      userPrompt: body.userPrompt,
+      vectorResultsJson: body.vectorResultsJson,
+      r2OutputUrl: body.r2OutputUrl,
+    });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    console.error(e);
+    return new Response('Bad Request', { status: 400 });
+  }
+};

--- a/functions/api/topics.ts
+++ b/functions/api/topics.ts
@@ -1,0 +1,18 @@
+import { drizzle } from 'drizzle-orm/d1';
+import { sql } from 'drizzle-orm';
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  const db = drizzle(ctx.env.DB);
+  const { results } = (await db.run(
+    sql`SELECT main_topic FROM email_threads UNION SELECT main_topic FROM email_docs`
+  )) as { results: { main_topic: string | null }[] };
+
+  const topics = results
+    .map(r => r.main_topic)
+    .filter((t): t is string => !!t)
+    .sort();
+
+  return new Response(JSON.stringify({ topics }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/functions/openapi.json.ts
+++ b/functions/openapi.json.ts
@@ -1,0 +1,7 @@
+import spec from '../public/openapi.json';
+
+export const onRequest: PagesFunction = async () => {
+  return new Response(JSON.stringify(spec), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Cloudflare RAG API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/topics": {
+      "get": {
+        "summary": "List all main topics",
+        "responses": {"200": {"description": "List of topics"}}
+      }
+    },
+    "/sessions": {
+      "post": {
+        "summary": "Store chat session information",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {"$ref": "#/components/schemas/ChatSession"}
+            }
+          }
+        },
+        "responses": {"201": {"description": "Stored"}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChatSession": {
+        "type": "object",
+        "properties": {
+          "sessionId": {"type": "string"},
+          "mainTopic": {"type": "string"},
+          "userPrompt": {"type": "string"},
+          "vectorResultsJson": {"type": "string"},
+          "r2OutputUrl": {"type": "string"}
+        },
+        "required": ["sessionId"]
+      }
+    }
+  }
+}

--- a/schema.ts
+++ b/schema.ts
@@ -1,4 +1,5 @@
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
 
 export const documents = sqliteTable('documents', {
   id: text('id').primaryKey(),
@@ -14,4 +15,57 @@ export const documentChunks = sqliteTable('document_chunks', {
   documentId: text('document_id').references(() => documents.id),
   text: text('text'),
   sessionId: text('session_id'),
+});
+
+export const emailThreads = sqliteTable('email_threads', {
+  threadId: text('thread_id').primaryKey(),
+  threadUrl: text('thread_url'),
+  pdfUrl: text('pdf_url'),
+  numMessages: integer('num_messages'),
+  numAttachments: integer('num_attachments'),
+  attachmentsJson: text('attachments_json'),
+  parties: text('parties'),
+  subject: text('subject'),
+  dateFirstMessage: text('date_first_message'),
+  dateLastMessage: text('date_last_message'),
+  tags: text('tags'),
+  mainTopic: text('main_topic'),
+  messageSummariesJson: text('message_summaries_json'),
+  ragKey: text('rag_key'),
+  createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+  lastUpdated: text('last_updated').default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const emailDocs = sqliteTable('email_docs', {
+  docId: text('doc_id').primaryKey(),
+  source: text('source'),
+  parentId: text('parent_id'),
+  driveUrl: text('drive_url'),
+  r2FileUrl: text('r2_file_url'),
+  parentFolderId: text('parent_folder_id'),
+  pdfUrl: text('pdf_url'),
+  title: text('title'),
+  type: text('type'),
+  tags: text('tags'),
+  mainTopic: text('main_topic'),
+  relatedThreadId: text('related_thread_id'),
+  description: text('description'),
+  geminiSummary: text('gemini_summary'),
+  geminiTopics: text('gemini_topics'),
+  dateUploaded: text('date_uploaded'),
+  uploadedBy: text('uploaded_by'),
+  fileSizeBytes: integer('file_size_bytes'),
+  mimeType: text('mime_type'),
+  ragKey: text('rag_key'),
+  createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+  lastUpdated: text('last_updated').default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const chatSessions = sqliteTable('chat_sessions', {
+  sessionId: text('session_id').primaryKey(),
+  mainTopic: text('main_topic'),
+  userPrompt: text('user_prompt'),
+  vectorResultsJson: text('vector_results_json'),
+  r2OutputUrl: text('r2_output_url'),
+  createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
 });


### PR DESCRIPTION
## Summary
- define tables for `email_threads`, `email_docs` and `chat_sessions`
- provide SQL migration for new tables
- expose `/api/sessions` and `/api/topics` endpoints
- ship minimal OpenAPI spec and `/openapi.json` route
- document new REST API support in README

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@cloudflare/workers-types/2023-07-01')*

------
https://chatgpt.com/codex/tasks/task_e_684881e318ec832e9e1484ec6896c908